### PR TITLE
Added dummy data

### DIFF
--- a/db/seeds.sql
+++ b/db/seeds.sql
@@ -1,0 +1,51 @@
+/*
+--users
+insert into users(name, email, uid, pwd,createdAt, updatedAt) values
+('Abhijit', 'ag@gmail.com','ag1','aagg1', current_timestamp(),current_timestamp());
+
+insert into users(name, email, uid, pwd,createdAt, updatedAt) values
+('Manasi', 'ms@gmail.com','ms1','mmss1',current_timestamp(),current_timestamp());
+
+insert into users(name, email, position, uid, pwd,createdAt, updatedAt) values
+('Ted', 'ty@gmail.com','Associate','ty1','ttyy1',current_timestamp(),current_timestamp());
+
+insert into users(name, email, position, uid, pwd,createdAt, updatedAt) values
+('Brian', 'bj@gmail.com','Associate','bj1','bbjj1',current_timestamp(),current_timestamp());
+
+*/
+
+
+/*packages
+
+insert into packages (packageName,createdAt,updatedAt,UserId)
+values
+('A1',current_timestamp(),current_timestamp(),1);
+
+
+insert into packages (packageName,createdAt,updatedAt,UserId)
+values
+('A2',current_timestamp(),current_timestamp(),2)
+
+*/
+
+
+/*user info
+insert into userinfos (number, building, street, createdAt, updatedAt,UserId)
+values
+('1111','AAA','AAA1',current_timestamp(),current_timestamp(),1);
+
+insert into userinfos (number, building, street, createdAt, updatedAt,UserId)
+values
+('2222','MMM','MMM1',current_timestamp(),current_timestamp(),2);
+
+
+insert into userinfos (number, building, street, createdAt, updatedAt,UserId)
+values
+('3333','TTT','TTT1',current_timestamp(),current_timestamp(),3);
+
+
+insert into userinfos (number, building, street, createdAt, updatedAt,UserId)
+values
+('4444','BBB','BBB1',current_timestamp(),current_timestamp(),4);
+
+*/

--- a/models/package.js
+++ b/models/package.js
@@ -17,14 +17,26 @@ module.exports = function(sequelize, DataTypes) {
       defaultValue: "Bob"
     },
     updater:{
-	  type: DataTypes.STRING,
-      defaultValue: "Bob"
-    },
-    pickUpDate:{
-      type: DataTypes.DATE,
-      allowNull:true	
-    }
-  });
+     type: DataTypes.STRING,
+     defaultValue: "Bob"
+   },
+   pickUpDate:{
+    type: DataTypes.DATE,
+    allowNull:true	
+  },
+
+  createdAt:{
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW()
+
+  },
+
+  updatedAt:{
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW()
+
+  }
+});
 
   Package.associate = function(models) {
     Package.belongsTo(models.User, {

--- a/models/user.js
+++ b/models/user.js
@@ -24,14 +24,26 @@ module.exports = function(sequelize, DataTypes) {
     //   defaultValue: true
     // },
     uid:{
-	    type: DataTypes.STRING,
-      defaultValue: "Bob"
-    },
-    pwd:{
-      type: DataTypes.STRING,
-      allowNull:true	
-    }
-  });
+     type: DataTypes.STRING,
+     defaultValue: "Bob"
+   },
+   pwd:{
+    type: DataTypes.STRING,
+    allowNull:true	
+  },
+
+  createdAt:{
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW()
+
+  },
+
+  updatedAt:{
+    type: DataTypes.DATE,
+    defaultValue: DataTypes.NOW()
+
+  }
+});
 
   User.associate = function(models) {
     User.hasOne(models.UserInfo, {

--- a/models/userInfo.js
+++ b/models/userInfo.js
@@ -18,6 +18,17 @@ module.exports = function(sequelize, DataTypes) {
       type: DataTypes.STRING,
       defaultValue: 'Resident',
       len: [1]
+    },
+    createdAt:{
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW()
+
+    },
+
+    updatedAt:{
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW()
+
     }
   });
   


### PR DESCRIPTION
1. Dummy data added for users, usersInfo and packages in seeds.sql.
2. Updated models for users, usersInfo and packages to accept default current timestamp for createdAt and updatedAt fields. (still not working, will need to look into the functions later)